### PR TITLE
PRs fall back to TEST images, not PROD

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -257,16 +257,6 @@ jobs:
           fi
           echo "Image promotion not required"
 
-      - name: Promote Backend Image
-        if: steps.check.outputs.build == 'true'
-        uses: shrink/actions-docker-registry-tag@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          repository: ${{ github.repository }}
-          target: ${{ env.PREV }}-${{ env.COMPONENT }}
-          tags: |
-            ${{ env.ZONE }}-${{ env.COMPONENT }}
-
   image-frontend:
     name: Frontend Image Handling
     needs:
@@ -307,16 +297,6 @@ jobs:
             exit 0
           fi
           echo "Image promotion not required"
-
-      - name: Promote Backend Image
-        if: steps.check.outputs.build == 'true'
-        uses: shrink/actions-docker-registry-tag@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          repository: ${{ github.repository }}
-          target: ${{ env.PREV }}-${{ env.COMPONENT }}
-          tags: |
-            ${{ env.ZONE }}-${{ env.COMPONENT }}
 
   deploy-prod:
     name: PROD Deployment

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       component: ${{ matrix.component }}
       img_build: ${{ github.event.number }}
-      img_fallback: prod
+      img_fallback: test
       triggers: ${{ matrix.triggers }}
 
   tests:


### PR DESCRIPTION
PRs had been either building images or reusing ones from PROD.  Some teams are not going to PROD frequently, so it makes sense to use TEST images instead.

(There was also some redundant image promotion code that's been removed.)